### PR TITLE
correct wrongly named default_max_wait_time in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ looking for that content for a brief time. You can adjust how long this period
 is (the default is 2 seconds):
 
 ```ruby
-Capybara.default_max_wait_time = 5
+Capybara.default_wait_time = 5
 ```
 
 Be aware that because of this behaviour, the following two statements are **not**


### PR DESCRIPTION
Should be default_wait_time.
